### PR TITLE
Fix alignment's GetCurve for EdgeTX versions >= 2.9.0

### DIFF
--- a/SD-CARD/SCRIPTS/TELEMETRY/JFXJ/ALIGN.lua
+++ b/SD-CARD/SCRIPTS/TELEMETRY/JFXJ/ALIGN.lua
@@ -62,9 +62,15 @@ local function GetCurve(crvIndex)
 	local newTbl = {}
 	local oldTbl = model.getCurve(crvIndex)
 	
-	newTbl.y = {}
-	for p = 1, ui.n do
-		newTbl.y[p] = oldTbl.y[p - 1]
+	-- EdgeTX starting from commit 8f3dd7f72 emits the curves with the first point being 1,
+	-- conversion only required for versions older than v2.9.0 which did emit the "0"th element
+	if oldTbl.y[0] == nil then
+	    newTbl.y = oldTbl.y
+	else
+	    newTbl.y = {}
+	    for p = 1, ui.n do
+		    newTbl.y[p] = oldTbl.y[p - 1]
+	    end
 	end
 	
 	newTbl.smooth = 1

--- a/SD-CARD/SCRIPTS/TELEMETRY/JFXJ/BRKCRV.lua
+++ b/SD-CARD/SCRIPTS/TELEMETRY/JFXJ/BRKCRV.lua
@@ -31,9 +31,15 @@ local function GetCurve(crvIndex)
 	local newTbl = {}
 	local oldTbl = model.getCurve(crvIndex)
 	
-	newTbl.y = {}
-	for i = 1, ui.n do
-		newTbl.y[i] = oldTbl.y[i - 1]
+	-- EdgeTX starting from commit 8f3dd7f72 emits the curves with the first point being 1,
+	-- conversion only required for versions older than v2.9.0 which did emit the "0"th element
+	if oldTbl.y[0] == nil then
+	    newTbl.y = oldTbl.y
+	else
+	    newTbl.y = {}
+	    for p = 1, ui.n do
+		    newTbl.y[p] = oldTbl.y[p - 1]
+	    end
 	end
 	
 	newTbl.smooth = 0

--- a/SD-CARD/SCRIPTS/TELEMETRY/JFXK/ALIGN.lua
+++ b/SD-CARD/SCRIPTS/TELEMETRY/JFXK/ALIGN.lua
@@ -46,10 +46,17 @@ local function GetCurve(crvIndex)
 	local newTbl = {}
 	local oldTbl = model.getCurve(crvIndex)
 	
-	newTbl.y = {}
-	for p = 1, ui.n do
-		newTbl.y[p] = oldTbl.y[p - 1]
+	-- EdgeTX starting from commit 8f3dd7f72 emits the curves with the first point being 1,
+	-- conversion only required for versions older than v2.9.0 which did emit the "0"th element
+	if oldTbl.y[0] == nil then
+	    newTbl.y = oldTbl.y
+	else
+	    newTbl.y = {}
+	    for p = 1, ui.n do
+		    newTbl.y[p] = oldTbl.y[p - 1]
+	    end
 	end
+
 	
 	newTbl.smooth = 1
 	newTbl.name = oldTbl.name


### PR DESCRIPTION
In commit [8f3dd7f72e878607ab28af2b0c8ccca6e835fdd5](https://github.com/EdgeTX/edgetx/commit/8f3dd7f72e878607ab28af2b0c8ccca6e835fdd5) EdgeTX started to emit the curve elements with the first element in the list having the index 1. This is expected in LUA world but wasn't previously the case.

SoarETX used to workaround the situation by rewriting the curve table. With this commit the curve table is only rewritten when the curve retrieved from EdgeTX does contain an element starting at position 0.

I encountered this while trying SoarETX on RM Boxer (in the simulator) and on my new RM Pocket. On both the aileron alignment dialog works with this change. I've not tested older EdgeTX versions yet.